### PR TITLE
Close WebSocket properly when being cleaned up

### DIFF
--- a/market_maker/bitmex.py
+++ b/market_maker/bitmex.py
@@ -44,6 +44,9 @@ class BitMEX(object):
         self.ws = BitMEXWebsocket()
         self.ws.connect(base_url, symbol, shouldAuth=shouldWSAuth)
 
+    def __del__(self):
+        self.ws.exit()
+        
     #
     # Public methods
     #


### PR DESCRIPTION
Try to shut the websocket thread down properly. Current behaviour basically kills it in the middle of whatever it was doing resulting in a "Segmentation fault" exit status at times.

Technically, a similar method could be added to the `BitMEXWebsocket` class itself but it doesn't seem to have the same effect for reasons that elude me.