### PR TITLE
Update ws_thread.py

### DIFF
--- a/market_maker/ws/ws_thread.py
+++ b/market_maker/ws/ws_thread.py
@@ -1,5 +1,6 @@
 import sys
 import websocket
+import ssl
 import threading
 import traceback
 from time import sleep
@@ -151,7 +152,7 @@ class BitMEXWebsocket():
                                          on_error=self.__on_error,
                                          header=self.__get_auth())
 
-        self.wst = threading.Thread(target=lambda: self.ws.run_forever())
+        self.wst = threading.Thread(target=lambda: self.ws.run_forever(sslopt={"cert_reqs": ssl.CERT_NONE}))
         self.wst.daemon = True
         self.wst.start()
         self.logger.info("Started thread")


### PR DESCRIPTION
Fix cafile, capath and cadata cannot be all omitted error

When running the bot on both Ubuntu and Windows (circa June 2017), it won't start with a cafile, capath and cadata cannot be omitted error.

Fixed as per FAQ on https://github.com/websocket-client/websocket-client to disable SSL checking.

I'm guessing that another way to run it (more securely) would be to somehow add the Bitmex SSL certs to my system - perhaps that should be part of the install script instead?

Apologies if I have broken any github etiquette. I'm a bit of a noob at this.