### PR TITLE
shell script file to use in crontab

### DIFF
--- a/bitmex.sh
+++ b/bitmex.sh
@@ -1,0 +1,13 @@
+
+#!/bin/bash
+
+if [[ $(ps -ef | pgrep python) ]];
+then
+    echo "BitMEX bot is running already."
+else
+    echo "Need to start BitMEX bot."
+    cd ../../../..
+    cd /home/sample-market-maker-master // Set this path as per actuall path wheres you extract/unzip to Repository
+    nohup ./marketmaker &
+    echo "BitMEX bot restarted."
+fi


### PR DESCRIPTION


I have noticed that some time on retries bot is stopped automatically. For this issue i have write a small shell script which keep monitors to bot process that bot is running or not. if this shell script detect that bot process stopped it will restart to bot. and if shell script detect that bot process is running already than it will do nothing.
you can put this shell script file in any directory and in my case I have put this file into /home directory.
after it set this file permission executable with following command.
chmod +x bitmex.sh
and type/add following line in end in crontab by using "crontab -e" command
*5 * * * * sh /home/bitmex.sh