### PR TITLE
Sleep for 30 seconds after a ws connect failure

### DIFF
--- a/market_maker/ws/ws_thread.py
+++ b/market_maker/ws/ws_thread.py
@@ -170,6 +170,9 @@ class BitMEXWebsocket():
             conn_timeout -= 1
 
         if not conn_timeout or self._error:
+            self.logger.error("Couldn't connect to WS! Sleeping for 30 seconds to avoid rate limit.")
+            sleep(30)
+            
             self.logger.error("Couldn't connect to WS! Exiting.")
             self.exit()
             sys.exit(1)


### PR DESCRIPTION
It's useful to use something like pm2 to auto restart this program after a failure. If you get a single 429 error from trying to connect to the WS api too frequently, this program will error out, and pm2 will immediately restart it. This leads to a never-ending cycle of 429 errors, making it hard to find what originally may have caused the program to connect too frequently.

This commit adds a simple 30 second delay before quitting the program after a WS connect failure. This should give enough time to cool down the rate limiter so the log output contains useful errors, not 1000+ 429 errors.