### PR TITLE
Fix infinite loop when 'Connected to WS. Waiting for data …'

### DIFF
--- a/market_maker/ws/ws_thread.py
+++ b/market_maker/ws/ws_thread.py
@@ -162,13 +162,14 @@ class BitMEXWebsocket():
         self.wst.daemon = True
         self.wst.start()
         self.logger.info("Started thread")
+        self.__wait_ws(lambda: self.ws.sock and self.ws.sock.connected)
 
+    def __wait_ws(self, good_condition):
         # Wait for connect before continuing
-        conn_timeout = 5
-        while (not self.ws.sock or not self.ws.sock.connected) and conn_timeout and not self._error:
+        conn_timeout = 15
+        while (not good_condition()) and conn_timeout and not self._error:
             sleep(1)
             conn_timeout -= 1
-
         if not conn_timeout or self._error:
             self.logger.error("Couldn't connect to WS! Exiting.")
             self.exit()
@@ -193,13 +194,11 @@ class BitMEXWebsocket():
     def __wait_for_account(self):
         '''On subscribe, this data will come down. Wait for it.'''
         # Wait for the keys to show up from the ws
-        while not {'margin', 'position', 'order'} <= set(self.data):
-            sleep(0.1)
+        self.__wait_ws(lambda: {'margin', 'position', 'order'} <= set(self.data))
 
     def __wait_for_symbol(self, symbol):
         '''On subscribe, this data will come down. Wait for it.'''
-        while not {'instrument', 'trade', 'quote'} <= set(self.data):
-            sleep(0.1)
+        self.__wait_ws(lambda: {'instrument', 'trade', 'quote'} <= set(self.data))
 
     def __send_command(self, command, args):
         '''Send a raw command.'''


### PR DESCRIPTION
Almost the same as https://github.com/hashpuppy/sample-market-maker/commit/b750ee0a7f5317a740ff25eb3f22822f82b17e84, but refactored.

During sudden price change, Bitmex MM tends to unreliably connected to websocket with the message "Connected to WS. Waiting for data images...". While MM message says that it is subscribed, WS symbol or account data was actually not downloaded causing an infinite loop. This commit fix that and exit the MM.

