### PR TITLE
unifying logger usage

### DIFF
--- a/market_maker/utils/log.py
+++ b/market_maker/utils/log.py
@@ -1,14 +1,19 @@
 import logging
 from market_maker.settings import settings
 
+loggers = {}
+
 
 def setup_custom_logger(name, log_level=settings.LOG_LEVEL):
-    formatter = logging.Formatter(fmt='%(asctime)s - %(levelname)s - %(module)s - %(message)s')
-
-    handler = logging.StreamHandler()
-    handler.setFormatter(formatter)
+    if loggers.get(name):
+        return loggers[name]
 
     logger = logging.getLogger(name)
+    loggers[name] = logger
+
+    formatter = logging.Formatter(fmt='%(asctime)s - %(levelname)s - %(module)s - %(message)s')
+    handler = logging.StreamHandler()
+    handler.setFormatter(formatter)
     logger.setLevel(log_level)
     logger.addHandler(handler)
     return logger


### PR DESCRIPTION
This prevents multiple instantiations of the `logging`-singleton later on e.g. in custom strategies.
Otherwise, log messages are as much repeated as too often initialized.

Furthermore, inconsistencies in the current API are mitigated as well by enforcing the usage of `utils.log` and only `utils.log`.