### PR TITLE
Updated README with the fix on the error __on_error() takes 2 positional arguments but 3 were given

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ Common errors we've seen:
 
 * `TypeError: __init__() got an unexpected keyword argument 'json'`
   * This is caused by an outdated version of `requests`. Run `pip install -U requests` to update.
+* `__on_error() takes 2 positional arguments but 3 were given`
+  * This can be resolved by installing `websocket-client` with `pip install -U websocket-client`
 
 
 ## Compatibility


### PR DESCRIPTION
When I tried to do the setup from README, on different machines I kept on getting error `__on_error() takes 2 positional arguments but 3 were given`. I resolved it by installing `websocket-client` with `pip install -U websocket-client`